### PR TITLE
Log the child process stdout and stderr properly

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -28,10 +28,12 @@ function browserClosedLog(browser) {
 
 function startBrowser(browserName, browser, url, id) {
     /*jshint validthis: true */
+    var logger = this._logger;
+    
     if (browser.prepareStart) {
-        this._logger.info("prepare start");
+        logger.info("prepare start");
         var prepareStartCommand = browser.prepareStart;
-        this._logger.debug(prepareStartCommand);
+        logger.debug(prepareStartCommand);
         cp.exec(
             prepareStartCommand,
             processLog.bind(this)
@@ -46,11 +48,17 @@ function startBrowser(browserName, browser, url, id) {
         startArgs.push(url);
     }
 
-    this._logger.info("start browser " + browserName);
+    logger.info("start browser " + browserName);
     
     var process = cp.spawn(startCommand, startArgs);
-    process.stdout.on('data', this._logger.debug);
-    process.stderr.on('data', this._logger.error);
+
+    process.stdout.on('data', function(buffer){
+        logger.debug(buffer.toString('utf8'))
+    });
+    process.stderr.on('data', function(buffer){
+        logger.error(buffer.toString('utf8'))
+    });
+
     process.on('close', browserClosedLog.bind(this, browserName));
     browser.process = process;
 }


### PR DESCRIPTION
`process.stdout` and `process.stderr` data event passes a buffer object which needs to be converted to a utf8 string in order to be properly consumed by the logger.
