### PR TITLE
Update node-ffi for 0.12 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,7 @@
 language: node_js
+
+node_js:
+   - "0.10"
+   - "0.12"
+
+sudo: false

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   	"async": "~0.9"
   },
   "optionalDependencies": {
-  	"ffi": "~1.2",
+  	"ffi": "~1.3",
   	"ref": "~0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
`node-ffi` prior to `1.3` doesn't build with `node@0.12`

See https://github.com/node-ffi/node-ffi/issues/187

This means that `buster-ci` doesn't build for `node@0.12`, and in turn that `buster` doesn't build for `node@0.12`.

Once this gets merged and published, we can create PRs for `buster-ci` and `buster`, and then finally publish an update to `buster` that will allow it to be used under `node@0.12` 
