### PR TITLE
ref v1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "optionalDependencies": {
   	"ffi": "~1.3",
-  	"ref": "~0.3"
+  	"ref": "~1.0"
   },
   "devDependencies": {
     "buster": "*",


### PR DESCRIPTION
Fixes building with iojs v2.4.0 and shrinkwrap

Without this change `ref` is not compiled successfully, which shouldn't be an issue in itself, but `ffi` also requires `ref` and a bug in npm makes required dependencies of a sub-module to optional dependencies when the same dependency is specified as optional dependency in the parent.

Should be fixed in npm@3

shrinkwrap error:

```
Please correct and try again.
missing: ref@*, required by ffi@1.3.1
```

The new ref version does not include any breaking changes:
https://github.com/TooTallNate/ref/blob/master/History.md
